### PR TITLE
fix: unicode_binary_pick function_clause

### DIFF
--- a/src/triq_dom.erl
+++ b/src/triq_dom.erl
@@ -1521,7 +1521,7 @@ unicode_binary(Size, Encoding) ->
 
 unicode_binary_pick(#?DOM{kind=#unicode_binary{size=Size, encoding=Encoding},
                           empty_ok=EmptyOK}=BinDom, SampleSize)
-  when SampleSize > 1 ->
+  when SampleSize > 0 ->
     Sz = case Size of
              any ->
                  case EmptyOK of


### PR DESCRIPTION
```erl
%%% BEFORE
triq_dom:pick(triq_dom:unicode_binary(), 1). 
** exception error: no function clause matching triq_dom:unicode_binary_pick({'@',{unicode_binary,any,utf8},
                                                                                  #Fun<triq_dom.65.74276917>,#Fun<triq_dom.66.74276917>,true},
                                                                             1)
%%% AFTER
triq_dom:pick(triq_dom:unicode_binary(), 1).
{{'@',{unicode_binary,any,utf8},
      #Fun<triq_dom.65.102128918>,#Fun<triq_dom.66.102128918>,
      true},
 <<>>}
```